### PR TITLE
Installation will fail if /tmp is in a noexec partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Installation Notes
 
 In order to use AIL combined with **ZFS** or **unprivileged LXC** it's necessary to disable Direct I/O in `$AIL_HOME/configs/6382.conf` by changing the value of the directive `use_direct_io_for_flush_and_compaction` to `false`.
 
+The partition hosting `/tmp` needs to be executable, otherwise, installation of `ssdeep`-related Python library will fail.
+
 Python 3 Upgrade
 ------------
 


### PR DESCRIPTION
The installation fails with /tmp on a noexec partition.

The important part of the error is:
`ImportError: /tmp/pip-install-g6nbfqw9/ssdeep/.eggs/cffi-1.12.2-py3.6-linux-x86_64.egg/_cffi_backend.cpython-36m-x86_64-linux-gnu.so: failed to map segment from shared object`

To solve the problem, remount with exec.